### PR TITLE
Add ability to verify certificate begin time

### DIFF
--- a/lib/Net/SSL/ExpireDate.pm
+++ b/lib/Net/SSL/ExpireDate.pm
@@ -127,6 +127,24 @@ sub begin_date {
 *not_after  = \&expire_date;
 *not_before = \&begin_date;
 
+sub is_begun {
+    my ($self, $duration) = @_;
+    $duration ||= DateTime::Duration->new();
+
+    if (! $self->{begin_date}) {
+        $self->expire_date;
+    }
+
+    if (! ref($duration)) { # if scalar
+        $duration = DateTime::Duration->new(seconds => parse_duration($duration));
+    }
+
+    my $dx = DateTime->now()->subtract_duration( $duration );
+    ### dx: $dx->iso8601
+
+    return DateTime->compare($dx, $self->{expire_date}) >= 0 ? 1 : ();
+}
+
 sub is_expired {
     my ($self, $duration) = @_;
     $duration ||= DateTime::Duration->new();


### PR DESCRIPTION
Add method is_begun() to check whether the certificate start time is valid. It works exactly like is_expired(), a shameless copy-paste-modify.