### PR TITLE
"record type is SSL3_AL_FATAL" occurred (added suppoted groups)

### DIFF
--- a/lib/Net/SSL/ExpireDate.pm
+++ b/lib/Net/SSL/ExpireDate.pm
@@ -190,10 +190,11 @@ sub _peer_certificate {
         if ($record->{type} != $SSL3_RT_HANDSHAKE) {
             if ($record->{type} == $SSL3_RT_ALERT) {
                 my $d1 = unpack 'C', substr $record->{data}, 0, 1;
+                my $d2 = unpack 'C', substr $record->{data}, 1, 1;
                 if ($d1 eq $SSL3_AL_WARNING) {
                     ; # go ahead
                 } else {
-                    croak "record type is SSL3_AL_FATAL";
+                    croak "record type is SSL3_AL_FATAL. [desctioption: $d2]";
                 }
             } else {
                 croak "record type is not HANDSHAKE";
@@ -365,6 +366,24 @@ sub _send_client_hello {
         for my $c (split //, $servername) {
             push @ext, ord($c);
         }
+    }
+
+    # Extension: supported_groups
+    push @ext, 0x00, 0x0a; # supported_groups
+    my @supportedGroups = (
+	0x000a, # sect163r1
+	0x0017, # secp256r1
+	0x0018, # secp384r1
+	0x0019, # secp521r1
+	0x001d, # x25519
+	0x001e, # x448
+    );
+    $len = scalar(@supportedGroups) * 2;
+    push @ext, (($len >> 8) & 0xFF);
+    push @ext, (($len     ) & 0xFF);
+    foreach my $i (@supportedGroups) {
+        push @ext, (($i >> 8) & 0xFF);
+        push @ext, (($i     ) & 0xFF);
     }
 
     # Extension: signature_algorithms (>= TLSv1.2)


### PR DESCRIPTION
In checking expiration date on www.groupon.jp, "record type is SSL3_AL_FATAL" occurred.

Actual behaviour:
   record type is SSL3_AL_FATAL at ./a.pl line 9
   Error!

I added supported extension to Net::SSL::ExpireDate referring to the openssl request,
it works well.

openssl request was create with the following command.
> openssl s_client -connect www.groupon.jp:443  -servername www.groupon.jp -tls1_2

And, I added description value to error message.

- Perl v5.10.1 (*) built for x86_64-linux-thread-multi
- Net::SSL::ExpireDate 1.20